### PR TITLE
Simplify FnCall

### DIFF
--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -369,15 +369,9 @@ let rec eval_sterm env = function
           tys origin
       in
       Value.VFunction { origin; value }
-  | FnCall { fn_name; args; dicts; _ } ->
+  | FnCall { fn; args; dicts; _ } ->
+      let f = Value.as_function (eval_sterm env fn) in
       let args = List.map (eval_cterm env) args in
-      let f =
-        match fn_name with
-        | Either.Left fnident -> Env.fn_declaration fnident env
-        | Right termident ->
-            let value = Env.lookup termident env in
-            Value.as_function value
-      in
       let dicts = List.map (eval_cterm env) dicts in
       (* HACK: pass dicts values with regulars arguments *)
       f (dicts @ args)

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -104,9 +104,9 @@ return_type=ty {
     }
     
 %inline fn_identifier:
-  | fn_name=Identifier DOT ty_resolve=option(sqrbracketed(ty)) dicts=option(anglebracketed(separated_list(COMMA, cterm)))  {
+  | fn=sterm DOT ty_resolve=option(sqrbracketed(ty)) dicts=option(anglebracketed(separated_list(COMMA, cterm)))  {
         let dicts = Option.value ~default:[] dicts in
-        fn_name, ty_resolve, dicts
+        fn, ty_resolve, dicts
     }
     
 %inline identifier_typed:
@@ -133,8 +133,8 @@ sterm:
         Lift {tys; func}
     }
     | fn=fn_identifier args=parenthesis(separated_list(COMMA, cterm)) {
-        let fn_name, ty_resolve, dicts = fn in
-        FnCall {fn_name = Either.Left fn_name; ty_resolve; dicts; args}
+        let fn, ty_resolve, dicts = fn in
+        FnCall {fn; ty_resolve; dicts; args}
     }
     | operator {
         Operator $1
@@ -148,12 +148,12 @@ sterm:
         args10=parenthesis(splitted(sterm, COMMA, sterm))
     {
         let acc, lterm = args10 in
-        let (fn_name, ty_resolve, dicts), const_args = fi in
+        let (fn, ty_resolve, dicts), const_args = fi in
         let const_args = Option.fold ~none:[] ~some:Fun.id const_args in
         List.init i Fun.id |> List.fold_left (fun acc i -> 
             let args = const_args @ (Synth acc) :: (Synth (Lookup {lterm; index = i})) :: [] in
-            FnCall {fn_name = Either.Left fn_name; ty_resolve; dicts; args }
-        ) acc 
+            FnCall {fn; ty_resolve; dicts; args }
+        ) acc
     }
     
 cterm:

--- a/lib/pass.ml
+++ b/lib/pass.ml
@@ -103,13 +103,12 @@ module Idents = struct
         let func = sterm env func in
         let tys = List.map (Fun.flip Env.find_tycstr env) tys in
         Lift { tys; func }
-    | FnCall { fn_name; ty_resolve; dicts; args } ->
-        let fn_name = Either.fold ~left:Fun.id ~right:Fun.id fn_name in
-        let fn_name = Env.find_callable fn_name env in
+    | FnCall { fn; ty_resolve; dicts; args } ->
+        let fn = sterm env fn in
         let ty_resolve = Option.map (ty env) ty_resolve in
         let dicts = List.map (cterm env) dicts in
         let args = List.map (cterm env) args in
-        FnCall { fn_name; ty_resolve; dicts; args }
+        FnCall { fn; ty_resolve; dicts; args }
     | Operator ops ->
         let op = Operator.map (cterm env) ops in
         Operator op

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -95,15 +95,9 @@ and typesynth env = function
           Ty.S.apps names bty
       | _ -> raise Ill_typed)
   | Operator operator -> typesynth_operator env operator
-  | FnCall { fn_name; ty_resolve; dicts; args } ->
+  | FnCall { fn; ty_resolve; dicts; args } ->
       let si =
-        match fn_name with
-        | Left fn_ident ->
-            let fn = Env.fn_declaration fn_ident env in
-            fn.signature
-        | Right x -> (
-            let ty = Env.ty_variable x env in
-            match ty with Fun si -> si | _ -> raise Ill_typed)
+        match typesynth env fn with Fun si -> si | _ -> raise Ill_typed
       in
       let ops, parameters, return_type =
         match (si.tyvars, ty_resolve) with


### PR DESCRIPTION
Dear Sir,

I've streamlined the definition of the `FnCall` constructor so that it takes an `sterm` instead of a choice of a term variable or a function identifier. Surprisingly, all the tests pass but I am pretty sure that the parser is wrong. I suspect that the test suite is not testing much..

Awaiting your careful code review.