### PR TITLE
Draft: distinguish standard arguments from polymorphic dictionaries in syntax

### DIFF
--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -55,6 +55,8 @@ rule token = parse
 | "}" { RBRACE }
 | "[" { LSQBRACE }
 | "]" { RSQBRACE }
+| "<" { LANGLE }
+| ">" { RANGLE }
 | "&" { AMPERSAND }
 | "," { COMMA }
 | "=" { EQUAL }

--- a/lib/prog.ml
+++ b/lib/prog.ml
@@ -11,7 +11,8 @@ type 't fndecl_ = {
     ; fn_ident : 'fn_ident
     ; ty_var : 'ty_var
     ; term_id : 'term_id >
-(** [fn f [a](x1: ty1, x2: ty2, ...) ty = t] *)
+(** [fn f [a]^?<op1: ty_op1, op2: ty_op2, ...>^?(x1: ty1, x2: ty2, ...) ty = t]
+*)
 
 let pp_fndecl_ pp_var pp_ty_var pp_ty_decl pp_fn_ident format fn =
   let pp_ty = Ty.pp_ pp_ty_var pp_ty_decl in

--- a/lib/prog.ml
+++ b/lib/prog.ml
@@ -1,6 +1,7 @@
 type 't fndecl_ = {
   fn_name : 'fn_ident;
   signature : 't Ty.signature;
+  ops : 'term_id list;
   args : 'term_id list;
   body : 't Term.cterm_;
 }
@@ -15,7 +16,7 @@ type 't fndecl_ = {
 let pp_fndecl_ pp_var pp_ty_var pp_ty_decl pp_fn_ident format fn =
   let pp_ty = Ty.pp_ pp_ty_var pp_ty_decl in
   let pp_term = Term.pp_cterm_ pp_var pp_ty_var pp_ty_decl pp_fn_ident in
-  let { fn_name; signature; args; body } = fn in
+  let { fn_name; signature; ops; args; body } = fn in
   let pp_parameter format (variable, ty) =
     Format.fprintf format "%a : %a" pp_var variable pp_ty ty
   in
@@ -28,10 +29,11 @@ let pp_fndecl_ pp_var pp_ty_var pp_ty_decl pp_fn_ident format fn =
       ~pp_sep:(fun format () -> Format.fprintf format ", ")
       pp_parameter
   in
+  let ops = List.combine ops signature.ops in
   let parameters = List.combine args signature.parameters in
-  Format.fprintf format "fn %a %a(%a) %a = %a" pp_fn_ident fn_name pp_tyvars
-    signature.tyvars pp_parameters parameters pp_ty signature.return_type
-    pp_term body
+  Format.fprintf format "fn %a %a<%a>(%a) %a = %a" pp_fn_ident fn_name pp_tyvars
+    signature.tyvars pp_parameters ops pp_parameters parameters pp_ty
+    signature.return_type pp_term body
 
 (* Type decl only create alias. *)
 type 't tydecl_ = {

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -11,7 +11,7 @@ type 't sterm_ =
       ty_resolve : 't Ty.t option;
       dicts : 't cterm_ list;
       args : 't cterm_ list;
-    }  (** [f.[ty](t1, t2, ...)] *)
+    }  (** [f.[ty]<op1, op2, ...>(t1, t2, ...)] *)
   | Operator of 't cterm_ Operator.t
   | Ann of 't cterm_ * 't Ty.t
   constraint

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -9,6 +9,7 @@ type 't sterm_ =
   | FnCall of {
       fn_name : ('fn_ident, 'term_id) Either.t;
       ty_resolve : 't Ty.t option;
+      dicts : 't cterm_ list;
       args : 't cterm_ list;
     }  (** [f.[ty](t1, t2, ...)] *)
   | Operator of 't cterm_ Operator.t
@@ -81,13 +82,13 @@ let pps pp_var pp_ty_var pp_ty_decl pp_fn_ident =
         Format.fprintf format "reindex[%a | %a](%a)" pp_decls lhs pp_decls rhs
           go_sterm_ lterm
     | Circ lterm -> Format.fprintf format "circ(%a)" go_sterm_ lterm
-    | FnCall { fn_name; ty_resolve; args } ->
+    | FnCall { fn_name; ty_resolve; dicts; args } ->
         let pp_ty_resolve =
           Format.pp_print_option (fun format ty ->
               Format.fprintf format "[%a]" pp_ty ty)
         in
-        Format.fprintf format "%a.%a(%a)" pp_fn_name fn_name pp_ty_resolve
-          ty_resolve pp_args args
+        Format.fprintf format "%a.%a<%a>(%a)" pp_fn_name fn_name pp_ty_resolve
+          ty_resolve pp_args dicts pp_args args
     | Ann (tm, ty) -> Format.fprintf format "(%a : %a)" go tm pp_ty ty
   and pp_terms format =
     Format.pp_print_list
@@ -135,11 +136,12 @@ module S = struct
     let variable = Ident.TermIdent.fresh variable in
     Let { variable; term; k = k (v variable) }
 
-  let fn_call ?resolve fn_name args =
-    FnCall { fn_name = Left fn_name; ty_resolve = resolve; args }
+  let fn_call ?ty fn_name dicts args =
+    let ty_resolve = ty in
+    FnCall { fn_name = Left fn_name; ty_resolve; dicts; args }
 
-  let v_call ?resolve variable_name args =
-    FnCall { fn_name = Right variable_name; ty_resolve = resolve; args }
+  let v_call ?ty_resolve variable_name dicts args =
+    FnCall { fn_name = Right variable_name; ty_resolve; dicts; args }
 
   let circ t = Circ t
   let lift tys func = Lift { tys; func }

--- a/lib/ty.ml
+++ b/lib/ty.ml
@@ -2,7 +2,8 @@ type 't t =
   | Bool  (** [bool] *)
   | Var of 'ty_var  (** ['a] *)
   | App of 't spine  (** [tname0 (tyname1 (... (tyname_n ty)))] *)
-  | Fun of 't signature  (** [['a]^? (ty1, ty2, ...) -> ty] *)
+  | Fun of 't signature
+      (** [['a]^? <ty_op1, ty_op2, ...>^?(ty1, ty2, ...) -> ty] *)
   constraint 't = < ty_var : 'ty_var ; ty_decl : 'ty_decl ; .. >
 
 and 't signature = {

--- a/lib/ty.ml
+++ b/lib/ty.ml
@@ -7,6 +7,7 @@ type 't t =
 
 and 't signature = {
   tyvars : 'ty_var option;
+  ops : 't t list;
   parameters : 't t list;
   return_type : 't t;
 }
@@ -48,12 +49,12 @@ module S = struct
         App { names; bty }
     | _ -> if List.is_empty names' then ty else App { names = names'; bty = ty }
 
-  let fn ?tyvars parameters return_type =
-    Fun { tyvars; parameters; return_type }
+  let fn ?tyvars ops parameters return_type =
+    Fun { tyvars; ops; parameters; return_type }
 end
 
 let rec bmap_signature on_binder on_var on_decl env
-    { tyvars; parameters; return_type } =
+    { tyvars; ops; parameters; return_type } =
   let env, tyvars =
     Option.fold ~none:(env, None)
       ~some:(fun v ->
@@ -61,9 +62,10 @@ let rec bmap_signature on_binder on_var on_decl env
         (e, Some v))
       tyvars
   in
+  let ops = List.map (bmap on_binder on_var on_decl env) ops in
   let parameters = List.map (bmap on_binder on_var on_decl env) parameters in
   let return_type = bmap on_binder on_var on_decl env return_type in
-  { tyvars; parameters; return_type }
+  { tyvars; ops; parameters; return_type }
 
 and bmap_spine on_binder on_var on_decl env { names; bty } =
   {
@@ -85,9 +87,9 @@ let pp_ pp_var pp_decl =
   let rec go format = function
     | Bool -> Format.fprintf format "bool"
     | App { names; bty } -> go_apps bty format names
-    | Fun { tyvars; parameters; return_type } ->
-        Format.fprintf format "fn %a(%a) -> %a" pp_var_opt tyvars gos parameters
-          go return_type
+    | Fun { tyvars; ops; parameters; return_type } ->
+        Format.fprintf format "fn %a<%a>(%a) -> %a" pp_var_opt tyvars gos ops
+          gos parameters go return_type
     | Var name -> Format.fprintf format "%a" pp_var name
   and go_apps ty format = function
     | [] -> go format ty
@@ -198,8 +200,9 @@ let free_vars ty =
     | Bool -> vars
     | Var s -> Vars.add s vars
     | App { bty; names = _ } -> free_vars vars bty
-    | Fun { tyvars; parameters; return_type } ->
+    | Fun { tyvars; ops; parameters; return_type } ->
         let vars = free_vars vars return_type in
+        let vars = List.fold_left free_vars vars ops in
         let vars = List.fold_left free_vars vars parameters in
         Option.fold ~none:vars ~some:(Fun.flip Vars.remove vars) tyvars
   in

--- a/lib/ty.mli
+++ b/lib/ty.mli
@@ -7,6 +7,7 @@ type 't t = private
 
 and 't signature = {
   tyvars : 'ty_var option;
+  ops : 't t list;
   parameters : 't t list;
   return_type : 't t;
 }
@@ -52,7 +53,11 @@ module S : sig
   val apps : 'ty_decl list -> (< ty_decl : 'ty_decl ; .. > as 'b) t -> 'b t
 
   val fn :
-    ?tyvars:'ty_var -> (< ty_var : 'ty_var ; .. > as 'b) t list -> 'b t -> 'b t
+    ?tyvars:'ty_var ->
+    (< ty_var : 'ty_var ; .. > as 'b) t list ->
+    'b t list ->
+    'b t ->
+    'b t
 end
 
 val to_spine : 't t -> 't spine

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -136,7 +136,7 @@ and typesynth env = function
       match ty with
       | Fun signature ->
           Ty.S.fn ?tyvars:signature.tyvars
-            (List.map (fun bty -> Ty.S.apps tys bty) signature.parameters)
+            (List.map (fun bty -> Ty.S.apps tys bty) signature.ops)
             (List.map (fun bty -> Ty.S.apps tys bty) signature.parameters)
             (Ty.S.apps tys signature.return_type)
       | _ -> raise Ill_typed)

--- a/test/src/test_reindex.ua
+++ b/test/src/test_reindex.ua
@@ -73,7 +73,7 @@ fn permbits ['a] (state : Col Row Slice 'a) Col Row Slice 'a =
     ] in
     let state = reindex[Col Row | Slice](state) in
     reindex[Slice | Col Row](
-        ( let+ f = permbits and slice = state in 
+        ( let+ f : Slice _ = permbits and slice = state in 
             f.['a](slice) : Slice Col Row 'a )
     )
     
@@ -88,7 +88,7 @@ fn permbits_0 ['a](state : Slice Col Row 'a) Slice Col Row 'a =
         ] in
         let state = reindex[Col Row | Slice]((state : Col Row Slice 'a)) in
         reindex[Slice | Col Row](
-            ( let+ f = permbits and slice = state in 
+            ( let+ f: Slice _ = permbits and slice = state in 
             f.['a](slice) : Slice Col Row 'a )
         ) : Col Row Slice 'a)
     )
@@ -104,7 +104,7 @@ fn permbits_1 ['a](state : Slice Col Row 'a) Slice Col Row 'a =
     ] in
     let state = reindex[Col Row | Slice]((state : Col Row Slice 'a)) in
     reindex[Slice | Col Row](
-        ( let+ f = permbits and slice = state in 
+        ( let+ f: Slice _ = permbits and slice = state in 
             f.['a](slice) : Slice Col Row 'a 
         )
     )
@@ -118,7 +118,7 @@ fn permbits_2 ['a](state : Slice Col Row 'a) Slice Col Row 'a =
         & rev_rotate_0
     ] in
     reindex[Slice | Col Row](
-        ( let+ f = permbits 
+        ( let+ f: Slice _ = permbits 
             and slice = reindex[Col Row | Slice](
                 (reindex[Slice | Col Row]((state : Slice Col Row 'a)) : Col Row Slice 'a)
             ) in 
@@ -134,7 +134,7 @@ fn permbits_bitslice ['a](state : Slice Col Row 'a) Slice Col Row 'a =
         & rev_rotate_3,
         & rev_rotate_0
     ] in
-    let+ f = permbits and slice = state in 
+    let+ f: Slice _ = permbits and slice = state in 
         f.['a](slice)
 
 fn subcells ['a](

--- a/test/src/test_reindex.ua
+++ b/test/src/test_reindex.ua
@@ -158,43 +158,42 @@ fn subcells ['a](
     Slice[s3, s1, s2, s0]
     
   
-fn subcells_bitslice ['a](
-    fnot : fn(Col Row 'a) -> Col Row 'a,
+fn subcells_bitslice ['a]<    fnot : fn(Col Row 'a) -> Col Row 'a,
     fand : fn(Col Row 'a, Col Row 'a) -> Col Row 'a,
     for : fn(Col Row 'a, Col Row 'a) -> Col Row  'a,
     fxor : fn(Col Row 'a, Col Row 'a) -> Col Row 'a,
+>(
     state : Slice Col Row 'a
 ) Slice Col Row 'a = 
-    subcells.[Col Row 'a](fnot, fand, for, fxor, state)
+    subcells.[Col Row 'a]<fnot, fand, for, fxor>(state)
     
   
-fn subcells_reindexed ['a] (
+fn subcells_reindexed ['a] <
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
+    fxor : fn('a, 'a) -> 'a >(
     state : Slice Col Row 'a
 ) Slice Col Row 'a = 
     let state = # reindex[Slice | Col Row](range(state)) in
     # reindex[Col Row | Slice](
         range(# let+ slice = range[Col Row](state) in 
-            subcells.['a](fnot, fand, for, fxor, slice)
+            subcells.['a]<fnot, fand, for, fxor>(slice)
         )
     )
     
-fn subcells ['a] ( 
-    fnot : fn('a) -> 'a,
+fn subcells ['a] <    fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
     fxor : fn('a, 'a) -> 'a,
+> ( 
     state : Col Row Slice 'a
 ) Col Row Slice 'a =
     # let+ slice = range[Col Row](state) in 
-        subcells.['a](fnot, fand, for, fxor, slice)
+        subcells.['a]<fnot, fand, for, fxor>(slice)
         
 
-fn add_round_key_reindexed['a](
-    fxor: fn('a, 'a) -> 'a,
+fn add_round_key_reindexed['a]<    fxor: fn('a, 'a) -> 'a>(
     state : Slice Col Row 'a,
     key : Slice Col Row 'a
 ) Slice Col Row 'a = 
@@ -207,35 +206,32 @@ fn add_round_key_reindexed['a](
         )
     )
 
-fn add_round_key ['a](
-    fxor: fn('a, 'a) -> 'a,
+fn add_round_key ['a]<    fxor: fn('a, 'a) -> 'a>(
     state : Col Row Slice 'a,
     key : Col Row Slice 'a
 ) Col Row Slice 'a =
     # let+ state = range[Col Row Slice](state) and key = range[Col Row Slice](key) in
         fxor.(state, key)
     
-fn round ['a] (
-    fnot : fn('a) -> 'a,
+fn round ['a]<    fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
+    fxor : fn('a, 'a) -> 'a> (
     state : Col Row Slice 'a,
     key : Col Row Slice 'a
 ) Col Row Slice 'a = 
-    let state = subcells.['a](fnot, fand, for, fxor, state) in
+    let state = subcells.['a]<fnot, fand, for, fxor>(state) in
     let state = permbits.['a](state) in
-    add_round_key.['a](fxor, state, key)
+    add_round_key.['a]<fxor>(state, key)
     
-fn gift ['a] (
-    fnot : fn('a) -> 'a,
+fn gift ['a] <    fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
+    fxor : fn('a, 'a) -> 'a>(
     state : Col Row Slice 'a, 
     keys : Keys Col Row Slice 'a
 ) Col Row Slice 'a = 
-    fold[28](round.['a](fnot, fand, for, fxor))(state, range(keys))
+    fold[28](round.['a]<fnot, fand, for, fxor>)(state, range(keys))
     
 fn fnot(b: bool) bool = ! b
 fn fand(lhs: bool, rhs: bool) bool = lhs & rhs
@@ -258,14 +254,10 @@ fn gift32(
     state : Col Row Slice Double bool,
     keys : Keys Col Row Slice Double bool
 ) Col Row Slice Double bool =
-    gift.[Double bool](
-        double_not, double_and, double_or, double_xor, state, keys
-    )
+    gift.[Double bool]<double_not, double_and, double_or, double_xor>(state, keys)
 
 fn gift16(
     state : Col Row Slice bool,
     keys : Keys Col Row Slice bool
 ) Col Row Slice bool =
-gift.[bool](
-    fnot, fand, for, fxor, state, keys
-) 
+gift.[bool]<fnot, fand, for, fxor>(state, keys) 

--- a/test/src/test_reindex2.ua
+++ b/test/src/test_reindex2.ua
@@ -182,118 +182,101 @@ fn permbits_bitslice ['a](state : Slice Col Row 'a) Slice Col Row 'a =
     let+ f : Slice _ = permbits and slice = state in 
         f.['a](slice)
         
-fn subcells_ ['a](
+fn subcells_ ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for  : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    slice : Slice 'a
-) Slice 'a = 
-    let s0 = slice[0] in
-    let s1 = slice[1] in
-    let s2 = slice[2] in
-    let s3 = slice[3] in
-    let s1 = fxor.(s1, fand.(s0, s2)) in
-    let s0 = fxor.(s0, fand.(s1, s3)) in
-    let s2 = fxor.(s2, for.(s0, s1)) in
-    let s3 = fxor.(s3, s2) in
-    let s1 = fxor.(s1, s3) in
-    let s3 = fnot.(s3) in
-    let s2 = fxor.(s2, fand.(s0, s1)) in
-    Slice [s3, s1, s2, s0]
+    fxor : fn('a, 'a) -> 'a>
+    (slice : Slice 'a) Slice 'a = 
+        let s0 = slice[0] in
+        let s1 = slice[1] in
+        let s2 = slice[2] in
+        let s3 = slice[3] in
+        let s1 = fxor.(s1, fand.(s0, s2)) in
+        let s0 = fxor.(s0, fand.(s1, s3)) in
+        let s2 = fxor.(s2, for.(s0, s1)) in
+        let s3 = fxor.(s3, s2) in
+        let s1 = fxor.(s1, s3) in
+        let s3 = fnot.(s3) in
+        let s2 = fxor.(s2, fand.(s0, s1)) in
+        Slice [s3, s1, s2, s0]
     
     
-fn subcells ['a] ( 
-    fnot : fn('a) -> 'a,
-    fand : fn('a, 'a) -> 'a,
-    for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Col Row Slice 'a
-) Col Row Slice 'a =
-    let+ slice : Col Row _ = state in
-    subcells_.['a](fnot, fand, for, fxor, slice)
+fn subcells ['a] 
+    <fnot : fn('a) -> 'a, fand : fn('a, 'a) -> 'a, 
+    for : fn('a, 'a) -> 'a, fxor : fn('a, 'a) -> 'a>
+    (state : Col Row Slice 'a) Col Row Slice 'a =
+        let+ slice : Col Row _ = state in
+        subcells_.['a]<fnot, fand, for, fxor>(slice)
     
-fn subcells_reindexed ['a] (
-    fnot : fn('a) -> 'a,
-    fand : fn('a, 'a) -> 'a,
-    for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a
-) Slice Col Row 'a = 
-    let state = reindex[Slice | Col Row]((state : Slice Col Row 'a)) in
-    reindex[Col Row | Slice](
-        (let+ slice : Col Row _ = state in
-         subcells_.['a](fnot, fand, for, fxor, slice) : Col Row Slice 'a)
-    )
+fn subcells_reindexed ['a]
+    <fnot : fn('a) -> 'a, fand : fn('a, 'a) -> 'a,
+    for : fn('a, 'a) -> 'a, fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a) Slice Col Row 'a = 
+        let state = reindex[Slice | Col Row]((state : Slice Col Row 'a)) in
+        reindex[Col Row | Slice](
+            (let+ slice : Col Row _ = state in
+            subcells_.['a]<fnot, fand, for, fxor>(slice) : Col Row Slice 'a)
+        )
     
 // inline
-fn subcells_1 ['a] (
+fn subcells_1 ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a
-) Slice Col Row 'a = 
-    reindex[Col Row | Slice](
-        (let+ slice  : Col Row _ = reindex[Slice | Col Row]((state : Slice Col Row 'a)) in
-         subcells_.['a](fnot, fand, for, fxor, slice) : Col Row Slice 'a)
-    )
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a) Slice Col Row 'a = 
+        reindex[Col Row | Slice](
+            (let+ slice  : Col Row _ = reindex[Slice | Col Row]((state : Slice Col Row 'a)) in
+            subcells_.['a]<fnot, fand, for, fxor>(slice) : Col Row Slice 'a)
+        )
     
 
 // ? range [X.. ] reindex[Y | X..] + lift
-fn subcells_2 ['a] (
+fn subcells_2 ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a
-) Slice Col Row 'a = 
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a) Slice Col Row 'a = 
     reindex[Col Row | Slice](
         reindex[Slice | Col Row](
-            subcells_.[Col Row 'a](lift[Col Row](fnot), lift[Col Row](fand), 
-                lift[Col Row](for), lift[Col Row](fxor), state)
+            subcells_.[Col Row 'a]<lift[Col Row](fnot), lift[Col Row](fand), 
+                lift[Col Row](for), lift[Col Row](fxor)>(state)
         )
     )
  
 // simplify reindex
-fn subcells_bitslice ['a] (
+fn subcells_bitslice ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a
-) Slice Col Row 'a = 
-    subcells_.[Col Row 'a](lift[Col Row](fnot), lift[Col Row](fand), 
-        lift[Col Row](for), lift[Col Row](fxor), state)
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a) Slice Col Row 'a = 
+    subcells_.[Col Row 'a]<lift[Col Row](fnot), lift[Col Row](fand), 
+        lift[Col Row](for), lift[Col Row](fxor)>(state)
 
-fn add_round_key ['a](
-    fxor: fn('a, 'a) -> 'a,
-    state : Col Row Slice 'a,
-    key : Col Row Slice 'a
-) Col Row Slice 'a =
-    let+ a_state : Col Row Slice _ = state and a_key = key in
-    fxor.(a_state, a_key)
+fn add_round_key ['a]
+    <fxor: fn('a, 'a) -> 'a>
+    (state : Col Row Slice 'a, key : Col Row Slice 'a) Col Row Slice 'a =
+        let+ a_state : Col Row Slice _ = state and a_key = key in
+        fxor.(a_state, a_key)
         
-fn add_round_key_reindexed['a](
-    fxor: fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a,
-    key : Slice Col Row 'a
-) Slice Col Row 'a = 
-    let key = reindex[Slice | Col Row]((key : Slice Col Row 'a)) in
-    let state = reindex[Slice | Col Row]((state : Slice Col Row 'a)) in
-    reindex[Col Row | Slice](
-        (let+ a_state : Col Row Slice _ = state and a_key = key in
-         fxor.(a_state, a_key) :
-            Col Row Slice 'a
+fn add_round_key_reindexed['a]
+    <fxor: fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, key : Slice Col Row 'a) Slice Col Row 'a = 
+        let key = reindex[Slice | Col Row]((key : Slice Col Row 'a)) in
+        let state = reindex[Slice | Col Row]((state : Slice Col Row 'a)) in
+        reindex[Col Row | Slice](
+            (let+ a_state : Col Row Slice _ = state and a_key = key in
+                fxor.(a_state, a_key) : Col Row Slice 'a
+            )
         )
-    )
         
 // inline    
-fn add_round_key_1 ['a](
-    fxor: fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a,
-    key : Slice Col Row 'a
-) Slice Col Row 'a =
+fn add_round_key_1 ['a]
+    <fxor: fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, key : Slice Col Row 'a) Slice Col Row 'a =
     reindex[Col Row | Slice](
         (let+ a_state : Col Row Slice _ = reindex[Slice | Col Row](state)
             and a_key = reindex[Slice | Col Row](key)
@@ -304,71 +287,59 @@ fn add_round_key_1 ['a](
     ) 
     
 // ? range [X.. ] reindex[Y | X..] + lift
-fn add_round_key_2 ['a](
-    fxor: fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a,
-    key : Slice Col Row 'a
-) Slice Col Row 'a =
-    reindex[Col Row | Slice](
-        reindex[Slice | Col Row](
-            (
-                let f = lift[Slice Col Row](fxor) in
-                f.(state, key) : Slice Col Row 'a)
+fn add_round_key_2 ['a]
+    <fxor: fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, key : Slice Col Row 'a) Slice Col Row 'a =
+        reindex[Col Row | Slice](
+            reindex[Slice | Col Row](
+                (
+                    let f = lift[Slice Col Row](fxor) in
+                    f.(state, key) : Slice Col Row 'a)
+            )
         )
-    )
 
 // simplify reindex
-fn add_round_key_bitslice ['a](
-    fxor: fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a,
-    key : Slice Col Row 'a
-) Slice Col Row 'a =
-    let f = lift[Slice Col Row](fxor) in
-    f.(state, key)
+fn add_round_key_bitslice ['a]
+    <fxor: fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, key : Slice Col Row 'a) Slice Col Row 'a =
+        let f = lift[Slice Col Row](fxor) in
+        f.(state, key)
     
-fn round ['a] (
+fn round ['a] <
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Col Row Slice 'a,
-    key : Col Row Slice 'a
-) Col Row Slice 'a = 
-    let state = subcells.['a](fnot, fand, for, fxor, state) in
-    let state = permbits.['a](state) in
-    add_round_key.['a](fxor, state, key)
+    fxor : fn('a, 'a) -> 'a>
+    (state : Col Row Slice 'a, key : Col Row Slice 'a) Col Row Slice 'a = 
+        let state = subcells.['a]<fnot, fand, for, fxor>(state) in
+        let state = permbits.['a](state) in
+        add_round_key.['a]<fxor>(state, key)
     
-fn round_bitslice ['a](
+fn round_bitslice ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a,
-    key : Slice Col Row 'a
-) Slice Col Row 'a = 
-    let state = subcells_bitslice.['a](fnot, fand, for, fxor, state) in
-    let state = permbits_bitslice.['a](state) in
-    add_round_key_bitslice.['a](fxor, state, key)
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, key : Slice Col Row 'a) Slice Col Row 'a = 
+        let state = subcells_bitslice.['a]<fnot, fand, for, fxor>(state) in
+        let state = permbits_bitslice.['a](state) in
+        add_round_key_bitslice.['a]<fxor>(state, key)
     
-fn gift ['a] (
+fn gift ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Col Row Slice 'a, 
-    keys : Keys Col Row Slice 'a
-) Col Row Slice 'a = 
-    fold[28](round.['a](fnot, fand, for, fxor))(state, keys)
+    fxor : fn('a, 'a) -> 'a>
+(state : Col Row Slice 'a, keys : Keys Col Row Slice 'a) Col Row Slice 'a = 
+    fold[28](round.['a]<fnot, fand, for, fxor>)(state, keys)
     
-fn gift_bitslice ['a] (
+fn gift_bitslice ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a, 
-    keys : Keys Slice Col Row 'a
-) Slice Col Row 'a = 
-    fold[28](round_bitslice.['a](fnot, fand, for, fxor))(state, keys)
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, keys : Keys Slice Col Row 'a) Slice Col Row 'a = 
+        fold[28](round_bitslice.['a]<fnot, fand, for, fxor>)(state, keys)
     
 fn fnot(b: bool) bool = ! b
 fn fand(lhs: bool, rhs: bool) bool = lhs & rhs
@@ -391,30 +362,24 @@ fn gift32(
     state : Col Row Slice Double bool,
     keys : Keys Col Row Slice Double bool
 ) Col Row Slice Double bool =
-    gift.[Double bool](
-        double_not, double_and, double_or, double_xor, state, keys
-    )
+    gift.[Double bool]
+        <double_not, double_and, double_or, double_xor>(state, keys)
 
 fn gift16(
     state : Col Row Slice bool,
     keys : Keys Col Row Slice bool
 ) Col Row Slice bool =
-    gift.[bool](
-        fnot, fand, for, fxor, state, keys
-    ) 
+    gift.[bool]<fnot, fand, for, fxor>(state, keys)
     
 fn giftb_32(
     state : Slice Col Row Double bool,
     keys : Keys Slice Col Row Double bool
 ) Slice Col Row Double bool =
-    gift_bitslice.[Double bool](
-        double_not, double_and, double_or, double_xor, state, keys
-    )
+    gift_bitslice.[Double bool]
+        <double_not, double_and, double_or, double_xor>(state, keys)
 
 fn giftb_16(
     state : Slice Col Row bool,
     keys : Keys Slice Col Row bool
 ) Slice Col Row bool =
-    gift_bitslice.[bool](
-        &fnot, &fand, &for, &fxor, state, keys
-    ) 
+    gift_bitslice.[bool]<&fnot, &fand, &for, &fxor>(state, keys) 

--- a/test/src/test_reindex_fs.ua
+++ b/test/src/test_reindex_fs.ua
@@ -334,117 +334,107 @@ fn permbits_fixslice_mod_27_ ['a](state : Slice Col Row 'a) Slice Col Row 'a =
 // apply `fix_delay` 28 times
     
 /// SUBCELLS
-fn subcells_ ['a](
+fn subcells_ ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for  : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    slice : Slice 'a
-) Slice 'a = 
-    let s0 = slice[0] in
-    let s1 = slice[1] in
-    let s2 = slice[2] in
-    let s3 = slice[3] in
-    let s1 = fxor.(s1, fand.(s0, s2)) in
-    let s0 = fxor.(s0, fand.(s1, s3)) in
-    let s2 = fxor.(s2, for.(s0, s1)) in
-    let s3 = fxor.(s3, s2) in
-    let s1 = fxor.(s1, s3) in
-    let s3 = fnot.(s3) in
-    let s2 = fxor.(s2, fand.(s0, s1)) in
-    Slice [s3, s1, s2, s0]
+    fxor : fn('a, 'a) -> 'a>
+    (slice : Slice 'a) Slice 'a = 
+        let s0 = slice[0] in
+        let s1 = slice[1] in
+        let s2 = slice[2] in
+        let s3 = slice[3] in
+        let s1 = fxor.(s1, fand.(s0, s2)) in
+        let s0 = fxor.(s0, fand.(s1, s3)) in
+        let s2 = fxor.(s2, for.(s0, s1)) in
+        let s3 = fxor.(s3, s2) in
+        let s1 = fxor.(s1, s3) in
+        let s3 = fnot.(s3) in
+        let s2 = fxor.(s2, fand.(s0, s1)) in
+        Slice [s3, s1, s2, s0]
     
     
-fn subcells ['a] ( 
+fn subcells ['a] <
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Col Row Slice 'a
-) Col Row Slice 'a =
-    let+ slice : Col Row _ = state in 
-        subcells_.['a](fnot, fand, for, fxor, slice)
+    fxor : fn('a, 'a) -> 'a>
+    (state : Col Row Slice 'a) Col Row Slice 'a =
+        let+ slice : Col Row _ = state in 
+            subcells_.['a]<fnot, fand, for, fxor>(slice)
     
-fn subcells_reindexed ['a] (
+fn subcells_reindexed ['a] <
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a
-) Slice Col Row 'a = 
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a) Slice Col Row 'a = 
     let state = reindex[Slice | Col Row]((state : Slice Col Row 'a)) in
     reindex[Col Row | Slice](
         (let+ slice : Col Row _ = state in 
-            subcells_.['a](fnot, fand, for, fxor, slice) : Col Row Slice 'a)
+            subcells_.['a]<fnot, fand, for, fxor>(slice) : Col Row Slice 'a)
     )
     
 // inline
-fn subcells_1 ['a] (
+fn subcells_1 ['a] <
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a
-) Slice Col Row 'a = 
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a) Slice Col Row 'a = 
     reindex[Col Row | Slice](
         (let+ slice : Col Row _ = reindex[Slice | Col Row]((state : Slice Col Row 'a)) in
-            subcells_.['a](fnot, fand, for, fxor, slice) : Col Row Slice 'a)
+            subcells_.['a]<fnot, fand, for, fxor>(slice) : Col Row Slice 'a)
     )
     
 
 // ? range [X.. ] reindex[Y | X..] + lift
-fn subcells_2 ['a] (
+fn subcells_2 ['a] <
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a
-) Slice Col Row 'a = 
-    reindex[Col Row | Slice](
-        reindex[Slice | Col Row](
-            subcells_.[Col Row 'a](lift[Col Row](fnot), lift[Col Row](fand), 
-                lift[Col Row](for), lift[Col Row](fxor), state)
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a) Slice Col Row 'a = 
+        reindex[Col Row | Slice](
+            reindex[Slice | Col Row](
+                subcells_.[Col Row 'a]
+                    <lift[Col Row](fnot), lift[Col Row](fand), 
+                    lift[Col Row](for), lift[Col Row](fxor)>
+                    (state)
+            )
         )
-    )
  
 // simplify reindex
-fn subcells_bitslice ['a] (
-    fnot : fn('a) -> 'a,
-    fand : fn('a, 'a) -> 'a,
-    for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a
-) Slice Col Row 'a = 
-    subcells_.[Col Row 'a](lift[Col Row](fnot), lift[Col Row](fand), 
-        lift[Col Row](for), lift[Col Row](fxor), state)
+fn subcells_bitslice ['a] 
+    <fnot : fn('a) -> 'a, fand : fn('a, 'a) -> 'a,
+    for : fn('a, 'a) -> 'a, fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a) Slice Col Row 'a = 
+        subcells_.[Col Row 'a]
+            <lift[Col Row](fnot), lift[Col Row](fand), 
+            lift[Col Row](for), lift[Col Row](fxor)>
+            (state)
 
-fn add_round_key ['a](
-    fxor: fn('a, 'a) -> 'a,
-    state : Col Row Slice 'a,
-    key : Col Row Slice 'a
-) Col Row Slice 'a =
-    let+ a_state : Col Row Slice _ = state and a_key = key in
-        fxor.(a_state, a_key)
+fn add_round_key ['a]
+    <fxor: fn('a, 'a) -> 'a>
+    (state : Col Row Slice 'a, key : Col Row Slice 'a) Col Row Slice 'a =
+        let+ a_state : Col Row Slice _ = state and a_key = key in
+            fxor.(a_state, a_key)
         
-fn add_round_key_reindexed['a](
-    fxor: fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a,
-    key : Slice Col Row 'a
-) Slice Col Row 'a = 
-    let key = reindex[Slice | Col Row]((key : Slice Col Row 'a)) in
-    let state = reindex[Slice | Col Row]((state : Slice Col Row 'a)) in
-    reindex[Col Row | Slice](
-        (let+ a_state : Col Row Slice _ = state and a_key = key in
-            fxor.(a_state, a_key) : Col Row Slice 'a
+fn add_round_key_reindexed['a]
+    <fxor: fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, key : Slice Col Row 'a) Slice Col Row 'a = 
+        let key = reindex[Slice | Col Row]((key : Slice Col Row 'a)) in
+        let state = reindex[Slice | Col Row]((state : Slice Col Row 'a)) in
+        reindex[Col Row | Slice](
+            (let+ a_state : Col Row Slice _ = state and a_key = key in
+                fxor.(a_state, a_key) : Col Row Slice 'a
+            )
         )
-    )
         
 // inline    
-fn add_round_key_1 ['a](
-    fxor: fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a,
-    key : Slice Col Row 'a
-) Slice Col Row 'a =
+fn add_round_key_1 ['a]
+    <fxor: fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, key : Slice Col Row 'a ) Slice Col Row 'a =
     reindex[Col Row | Slice](
         (let+ a_state : Col Row Slice _ = reindex[Slice | Col Row](state) 
             and a_key = reindex[Slice | Col Row](key) 
@@ -454,49 +444,41 @@ fn add_round_key_1 ['a](
     ) 
     
 // ? range [X.. ] reindex[Y | X..] + lift
-fn add_round_key_2 ['a](
-    fxor: fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a,
-    key : Slice Col Row 'a
-) Slice Col Row 'a =
-    reindex[Col Row | Slice](
-        reindex[Slice | Col Row](
-            (
-                let f = lift[Slice Col Row](fxor) in
-                f.(state, key) : Slice Col Row 'a)
+fn add_round_key_2 ['a]
+    <fxor: fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, key : Slice Col Row 'a ) Slice Col Row 'a =
+        reindex[Col Row | Slice](
+            reindex[Slice | Col Row](
+                (
+                    let f = lift[Slice Col Row](fxor) in
+                    f.(state, key) : Slice Col Row 'a)
+            )
         )
-    )
 
 // simplify reindex
-fn add_round_key_bitslice ['a](
-    fxor: fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a,
-    key : Slice Col Row 'a
-) Slice Col Row 'a =
-    let f = lift[Slice Col Row](fxor) in
-    f.(state, key)
+fn add_round_key_bitslice ['a]
+    <fxor: fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a,key : Slice Col Row 'a) Slice Col Row 'a =
+        let f = lift[Slice Col Row](fxor) in
+        f.(state, key)
     
-fn round_bitslice ['a](
+fn round_bitslice ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a,
-    key : Slice Col Row 'a
-) Slice Col Row 'a = 
-    let state = subcells_bitslice.['a](fnot, fand, for, fxor, state) in
-    let state = permbits_bitslice.['a](state) in
-    add_round_key_bitslice.['a](fxor, state, key)
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, key : Slice Col Row 'a) Slice Col Row 'a = 
+        let state = subcells_bitslice.['a]<fnot, fand, for, fxor>(state) in
+        let state = permbits_bitslice.['a](state) in
+        add_round_key_bitslice.['a]<fxor>(state, key)
     
-fn gift_bitslice ['a] (
+fn gift_bitslice ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a, 
-    keys : Keys Slice Col Row 'a
-) Slice Col Row 'a = 
-    fold[28](round_bitslice.['a](fnot, fand, for, fxor))(state, keys)
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, keys : Keys Slice Col Row 'a) Slice Col Row 'a = 
+        fold[28](round_bitslice.['a]<fnot, fand, for, fxor>)(state, keys)
     
 fn fnot(b: bool) bool = ! b
 fn fand(lhs: bool, rhs: bool) bool = lhs & rhs
@@ -519,9 +501,8 @@ fn giftb_32(
     state : Slice Col Row Double bool,
     keys : Keys Slice Col Row Double bool
 ) Slice Col Row Double bool =
-    gift_bitslice.[Double bool](
-        double_not, double_and, double_or, double_xor, state, keys
-    )
+    gift_bitslice.[Double bool]<
+        double_not, double_and, double_or, double_xor>(state, keys)
     
 
 fn permbits_mod_0 ['a](state: Slice Col Row 'a) 
@@ -562,46 +543,41 @@ fn permbits_mod_3 ['a](state : Slice Col Row 'a)
         let+ row : Col _ = state[3] in circ(row)[0]
     ]
 
-fn round_fix_ ['a](
+fn round_fix_ ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    permbits : fn ['a](Slice Col Row 'a) -> Slice Col Row 'a, 
+    fxor : fn('a, 'a) -> 'a>
+    (permbits : fn ['a](Slice Col Row 'a) -> Slice Col Row 'a, 
     state : Slice Col Row 'a,
     key : Slice Col Row 'a
-) Slice Col Row 'a = 
-    let state = subcells_bitslice.['a](fnot, fand, for, fxor, state) in
-    let state = permbits.['a](state) in
-    add_round_key_bitslice.['a](fxor, state, key)
+    ) Slice Col Row 'a = 
+        let state = subcells_bitslice.['a]<fnot, fand, for, fxor>(state) in
+        let state = permbits.['a](state) in
+        add_round_key_bitslice.['a]<fxor>(state, key)
 
-fn round_fixslice ['a](
+fn round_fixslice ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a, 
-    keys : Key4 Slice Col Row 'a
-) Slice Col Row 'a = 
-        let state = round_fix_.['a](fnot, fand, for, fxor, permbits_mod_0, state, keys[0]) in
-        let state = round_fix_.['a](fnot, fand, for, fxor, permbits_mod_1, state, keys[1]) in
-        let state = round_fix_.['a](fnot, fand, for, fxor, permbits_mod_2, state, keys[2]) in
-        round_fix_.['a](fnot, fand, for, fxor, permbits_mod_3, state, keys[3])
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, keys : Key4 Slice Col Row 'a) Slice Col Row 'a = 
+        let state = round_fix_.['a]<fnot, fand, for, fxor>(permbits_mod_0, state, keys[0]) in
+        let state = round_fix_.['a]<fnot, fand, for, fxor>(permbits_mod_1, state, keys[1]) in
+        let state = round_fix_.['a]<fnot, fand, for, fxor>(permbits_mod_2, state, keys[2]) in
+        round_fix_.['a]<fnot, fand, for, fxor>(permbits_mod_3, state, keys[3])
         
-fn gift_fixslice ['a](
+fn gift_fixslice ['a]<
     fnot : fn('a) -> 'a,
     fand : fn('a, 'a) -> 'a,
     for : fn('a, 'a) -> 'a,
-    fxor : fn('a, 'a) -> 'a,
-    state : Slice Col Row 'a,
-    keys : C7 Key4 Slice Col Row 'a
-) Slice Col Row 'a = 
-    fold[7](round_fixslice.['a](fnot, fand, for, fxor))(state, keys)
+    fxor : fn('a, 'a) -> 'a>
+    (state : Slice Col Row 'a, keys : C7 Key4 Slice Col Row 'a) Slice Col Row 'a = 
+        fold[7](round_fixslice.['a]<fnot, fand, for, fxor>)(state, keys)
 
 fn giftf_32(
     state : Slice Col Row Double bool,
     keys : C7 Key4 Slice Col Row Double bool
 ) Slice Col Row Double bool =
-    gift_fixslice.[Double bool](
-        double_not, double_and, double_or, double_xor, state, keys
-    )
+    gift_fixslice.[Double bool]<double_not, double_and, double_or, double_xor> 
+        (state, keys)

--- a/test/test_pass.ml
+++ b/test/test_pass.ml
@@ -1,8 +1,8 @@
 module Vars = Set.Make (Ua0.Ident.TyIdent)
 
 let ty = Alcotest.testable Ua0.Ty.pp Ua0.Ty.equal
-let f b = Ua0.Ty.S.(fn ~tyvars:b [ v b ] (v b))
-let f_free b = Ua0.Ty.S.(fn [ v b ] (v b))
+let f b = Ua0.Ty.S.(fn ~tyvars:b [] [ v b ] (v b))
+let f_free b = Ua0.Ty.S.(fn [] [ v b ] (v b))
 
 let test_free message () =
   let a = "'a" in

--- a/test/test_typecheck.ml
+++ b/test/test_typecheck.ml
@@ -21,12 +21,20 @@ let ty_f =
   Ty.
     {
       tyvars = Some alpha;
+      ops = [];
       parameters = Ty.S.[ bool; v alpha ];
       return_type = Ty.S.v alpha;
     }
 
 let def_f =
-  Prog.{ fn_name = f; signature = ty_f; args = [ x; y ]; body = Synth (Var y) }
+  Prog.
+    {
+      fn_name = f;
+      signature = ty_f;
+      ops = [];
+      args = [ x; y ];
+      body = Synth (Var y);
+    }
 
 let env0 =
   let open Ua0.Typecheck.Env in
@@ -108,7 +116,8 @@ let () =
           test_case "in" `Quick (fun () ->
               check_typesynth Env0
                 Term.S.(vfn f)
-                Ty.S.(fn ~tyvars:alpha ty_f.parameters ty_f.return_type));
+                Ty.S.(
+                  fn ~tyvars:alpha ty_f.ops ty_f.parameters ty_f.return_type));
         ] );
       ( "Lookup",
         [
@@ -130,23 +139,23 @@ let () =
         [
           test_case "well-typed" `Quick (fun () ->
               check_typesynth Env0
-                Term.S.(fn_call ~resolve:Ty.S.(v alpha) f [ s (v x); s (v y) ])
+                Term.S.(fn_call ~ty:Ty.S.(v alpha) f [] [ s (v x); s (v y) ])
                 Ty.S.(v alpha));
           test_case "well-typed instanciated" `Quick (fun () ->
               check_typesynth Env0
-                Term.S.(fn_call ~resolve:Ty.S.bool f [ s (v x); s (v x) ])
+                Term.S.(fn_call ~ty:Ty.S.bool f [] [ s (v x); s (v x) ])
                 Ty.S.bool);
           test_case "no arguments" `Quick (fun () ->
-              fail_typesynth Env0 Term.S.(fn_call ~resolve:Ty.S.(v alpha) f []));
+              fail_typesynth Env0 Term.S.(fn_call ~ty:Ty.S.(v alpha) f [] []));
           test_case "insufficiently applied" `Quick (fun () ->
               fail_typesynth Env0
-                Term.S.(fn_call ~resolve:Ty.S.(v alpha) f [ s (v x) ]));
+                Term.S.(fn_call ~ty:Ty.S.(v alpha) f [] [ s (v x) ]));
           test_case "wrong args" `Quick (fun () ->
               fail_typesynth Env0
-                Term.S.(fn_call ~resolve:Ty.S.(v alpha) f [ s (v y); s (v x) ]));
+                Term.S.(fn_call ~ty:Ty.S.(v alpha) f [] [ s (v y); s (v x) ]));
           test_case "ill-typed instanciation" `Quick (fun () ->
               fail_typesynth Env0
-                Term.S.(fn_call ~resolve:Ty.S.bool f [ s (v x); s (v y) ]));
+                Term.S.(fn_call ~ty:Ty.S.bool f [] [ s (v x); s (v y) ]));
         ] );
       ( "Ann",
         [
@@ -195,7 +204,7 @@ let () =
               check_typesynth Env0
                 Term.S.(lift [ _F; _G ] (vfn f))
                 Ty.S.(
-                  fn ~tyvars:alpha
+                  fn ~tyvars:alpha []
                     [ _F @ _G @ bool; _F @ _G @ v alpha ]
                     (_F @ _G @ v alpha)));
           test_case "not applicative" `Quick (fun () ->

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -32,8 +32,8 @@ let () =
               check_equal Ty.S.(apps [ _G; _H ] bool) Ty.S.(_G @ _H @ bool) true);
           test_case "equal" `Quick (fun () ->
               check_equal
-                Ty.S.(fn ~tyvars:alpha [ v alpha ] (v alpha))
-                Ty.S.(fn ~tyvars:beta [ v beta ] (v beta))
+                Ty.S.(fn ~tyvars:alpha [] [ v alpha ] (v alpha))
+                Ty.S.(fn ~tyvars:beta [] [ v beta ] (v beta))
                 true);
           test_case "not equal" `Quick (fun () ->
               check_equal Ty.S.(v alpha) Ty.S.(v beta) false);


### PR DESCRIPTION
Dear Sir,

In this PR, I enforce a syntactic distinction between actual function arguments and operations associated with a polymorphic  type (dictionary).

The PR is currently failing to parse and/or type-check the examples. I've updated `test_reindex2.ua` but not `test_fixslice.ua`